### PR TITLE
[Feat/#95] 플래너, 플래너 공유 타임테이블 연결 추가

### DIFF
--- a/core/designsystem/src/main/res/drawable/ic_small_arrow_right.xml
+++ b/core/designsystem/src/main/res/drawable/ic_small_arrow_right.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="4dp"
+    android:height="6dp"
+    android:viewportWidth="4"
+    android:viewportHeight="6">
+  <path
+      android:pathData="M3.57,2.5228C3.7976,2.722 3.7976,3.0761 3.57,3.2753L0.8293,5.6734C0.506,5.9563 0,5.7267 0,5.2972L0,0.5009C0,0.0714 0.506,-0.1582 0.8293,0.1246L3.57,2.5228Z"
+      android:fillColor="#11BC78"/>
+</vector>

--- a/presentation/planner/src/main/java/com/together/study/planner/main/PlannerScreen.kt
+++ b/presentation/planner/src/main/java/com/together/study/planner/main/PlannerScreen.kt
@@ -242,7 +242,7 @@ private fun PlannerScreen(
                     onDeleteDoneClick = onDeleteDoneClick,
                 )
 
-                1 -> { /* TODO: 타임테이블 연결 */ }
+                1 -> TimeTableScreen(timeTableState = timeTableState)
 
                 2 -> StatisticsScreen(statisticsState)
             }

--- a/presentation/planner/src/main/java/com/together/study/planner/main/TimeTableScreen.kt
+++ b/presentation/planner/src/main/java/com/together/study/planner/main/TimeTableScreen.kt
@@ -1,0 +1,201 @@
+package com.together.study.planner.main
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.res.vectorResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.together.study.common.state.UiState
+import com.together.study.common.type.planner.PlannerSubjectColor
+import com.together.study.designsystem.R.drawable.ic_small_arrow_right
+import com.together.study.designsystem.theme.GRAY200
+import com.together.study.designsystem.theme.TogedyTheme
+import com.together.study.designsystem.theme.WHITE
+import com.together.study.planner.model.TimeTable
+import java.time.LocalTime
+
+@Composable
+internal fun TimeTableScreen(
+    timeTableState: UiState<List<TimeTable>>,
+) {
+    when (timeTableState) {
+        is UiState.Loading -> {
+            TimeTableContent(timeTables = emptyList())
+        }
+
+        is UiState.Success -> {
+            TimeTableContent(timeTables = timeTableState.data)
+        }
+
+        else -> {}
+    }
+}
+
+@Composable
+private fun TimeTableContent(
+    timeTables: List<TimeTable>,
+) {
+    val currentTime = LocalTime.now()
+    val currentHour = currentTime.hour
+    val hours = (6..23).toList() + (0..5).toList()
+    val filledSlots = remember(timeTables) {
+        if (timeTables.isEmpty()) {
+            List(hours.size) { emptyMap<Int, Color>() }
+        } else {
+            buildMinuteSlotsFromEvents(hours, timeTables)
+        }
+    }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(color = GRAY200),
+    ) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+        ) {
+            itemsIndexed(hours) { hourIndex, hour ->
+                val isCurrentHour = hour == currentHour
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Box(
+                        modifier = Modifier.width(32.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = hour.toString().padStart(2, '0'),
+                            textAlign = TextAlign.Center,
+                            style = if (isCurrentHour) {
+                                TogedyTheme.typography.body13b.copy(
+                                    color = TogedyTheme.colors.green
+                                )
+                            } else {
+                                TogedyTheme.typography.body10m.copy(
+                                    color = TogedyTheme.colors.gray500
+                                )
+                            },
+                            modifier = Modifier.align(Alignment.Center),
+                        )
+                        if (isCurrentHour) {
+                            Icon(
+                                imageVector = ImageVector.vectorResource(ic_small_arrow_right),
+                                contentDescription = null,
+                                tint = TogedyTheme.colors.green,
+                                modifier = Modifier.align(Alignment.CenterEnd),
+                            )
+                        }
+                    }
+
+                    Spacer(modifier = Modifier.width(2.dp))
+
+                    Column(
+                        modifier = Modifier.weight(1f),
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .height(24.dp)
+                                .fillMaxWidth()
+                                .background(WHITE),
+                        ) {
+                            repeat(6) { segment ->
+                                Row(
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .fillMaxSize(),
+                                ) {
+                                    val segmentStartMinute = segment * 10
+                                    repeat(10) { minuteOffset ->
+                                        val minute = segmentStartMinute + minuteOffset
+                                        val filledColor = filledSlots[hourIndex][minute]
+                                        val background = filledColor ?: Color.Transparent
+                                        Box(
+                                            modifier = Modifier
+                                                .weight(1f)
+                                                .fillMaxSize()
+                                                .background(background)
+                                        )
+                                    }
+                                }
+                                if (segment < 5) {
+                                    Box(
+                                        modifier = Modifier
+                                            .width(1.dp)
+                                            .fillMaxSize()
+                                            .background(GRAY200),
+                                    )
+                                }
+                            }
+                        }
+                        Box(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(1.dp)
+                                .background(GRAY200),
+                        )
+                    }
+                }
+            }
+        }
+    }
+}
+
+private fun buildMinuteSlotsFromEvents(
+    hours: List<Int>,
+    events: List<TimeTable>,
+): List<Map<Int, Color>> {
+    val slots = List(hours.size) { mutableMapOf<Int, Color>() }
+    val hourIndexByValue = hours.withIndex().associate { it.value to it.index }
+    events.forEach { event ->
+        val start = LocalTime.parse(event.startTime)
+        val end = LocalTime.parse(event.endTime)
+        val color = Color(PlannerSubjectColor.fromString(event.subjectColor).color)
+        val crossesMidnight = end.isBefore(start) || end == start
+        var cursor = start
+        while (true) {
+            val hourIndex = hourIndexByValue[cursor.hour]
+            if (hourIndex != null) {
+                slots[hourIndex][cursor.minute] = color
+            }
+            cursor = cursor.plusMinutes(1)
+            if (crossesMidnight) {
+                if (cursor == end || (cursor.isAfter(end) && cursor.hour == end.hour)) break
+            } else {
+                if (!cursor.isBefore(end)) break
+            }
+        }
+    }
+    return slots.map { it.toMap() }
+}
+
+@Preview(showBackground = true)
+@Composable
+fun TimeTableScreenPreview() {
+    TogedyTheme {
+        TimeTableScreen(
+            timeTableState = UiState.Success(emptyList()),
+        )
+    }
+}

--- a/presentation/planner/src/main/java/com/together/study/planner/main/TimeTableScreen.kt
+++ b/presentation/planner/src/main/java/com/together/study/planner/main/TimeTableScreen.kt
@@ -32,6 +32,7 @@ import com.together.study.designsystem.theme.GRAY200
 import com.together.study.designsystem.theme.TogedyTheme
 import com.together.study.designsystem.theme.WHITE
 import com.together.study.planner.model.TimeTable
+import com.together.study.util.toLocalTimeWithSecond
 import java.time.LocalTime
 
 @Composable
@@ -260,10 +261,11 @@ private fun buildMinuteSlotsFromEvents(
     val slots = List(hours.size) { mutableMapOf<Int, Color>() }
     val hourIndexByValue = hours.withIndex().associate { it.value to it.index }
     events.forEach { event ->
-        val start = LocalTime.parse(event.startTime)
-        val end = LocalTime.parse(event.endTime)
+        val start = runCatching { event.startTime.toLocalTimeWithSecond() }.getOrNull() ?: return@forEach
+        val end = runCatching { event.endTime.toLocalTimeWithSecond() }.getOrNull() ?: return@forEach
         val color = Color(PlannerSubjectColor.fromString(event.subjectColor).color)
-        val crossesMidnight = end.isBefore(start) || end == start
+        if (start == end) return@forEach
+        val crossesMidnight = end.isBefore(start)
         var cursor = start
         while (true) {
             val hourIndex = hourIndexByValue[cursor.hour]

--- a/presentation/planner/src/main/java/com/together/study/planner/main/TimeTableScreen.kt
+++ b/presentation/planner/src/main/java/com/together/study/planner/main/TimeTableScreen.kt
@@ -1,6 +1,7 @@
 package com.together.study.planner.main
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -47,6 +48,96 @@ internal fun TimeTableScreen(
         }
 
         else -> {}
+    }
+}
+
+@Composable
+fun ShareTimeTableContent(
+    timeTables: List<TimeTable>,
+    modifier: Modifier = Modifier,
+) {
+    val hours = (6..23).toList() + (0..5).toList()
+    val filledSlots = remember(timeTables) {
+        if (timeTables.isEmpty()) {
+            List(hours.size) { emptyMap<Int, Color>() }
+        } else {
+            buildMinuteSlotsFromEvents(hours, timeTables)
+        }
+    }
+
+    Column(
+        modifier = modifier.fillMaxSize(),
+    ) {
+        LazyColumn(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(vertical = 8.dp)
+        ) {
+            itemsIndexed(hours) { hourIndex, hour ->
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Box(
+                        modifier = Modifier.width(28.dp),
+                        contentAlignment = Alignment.Center,
+                    ) {
+                        Text(
+                            text = hour.toString().padStart(2, '0'),
+                            textAlign = TextAlign.Center,
+                            style = TogedyTheme.typography.body10m.copy(
+                                color = TogedyTheme.colors.gray500
+                            ),
+                            modifier = Modifier.align(Alignment.Center),
+                        )
+                    }
+
+                    Spacer(modifier = Modifier.width(2.dp))
+
+                    Column(
+                        modifier = Modifier
+                            .weight(1f)
+                            .border(width = 1.dp, color = GRAY200),
+                    ) {
+                        Row(
+                            modifier = Modifier
+                                .height(20.dp)
+                                .fillMaxWidth()
+                                .background(WHITE),
+                        ) {
+                            repeat(6) { segment ->
+                                Row(
+                                    modifier = Modifier
+                                        .weight(1f)
+                                        .fillMaxSize(),
+                                ) {
+                                    val segmentStartMinute = segment * 10
+                                    repeat(10) { minuteOffset ->
+                                        val minute = segmentStartMinute + minuteOffset
+                                        val filledColor = filledSlots[hourIndex][minute]
+                                        val background = filledColor ?: Color.Transparent
+                                        Box(
+                                            modifier = Modifier
+                                                .weight(1f)
+                                                .fillMaxSize()
+                                                .background(background)
+                                        )
+                                    }
+                                }
+                                if (segment < 5) {
+                                    Box(
+                                        modifier = Modifier
+                                            .width(1.dp)
+                                            .fillMaxSize()
+                                            .background(GRAY200),
+                                    )
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
     }
 }
 

--- a/presentation/planner/src/main/java/com/together/study/planner/share/PlannerShareScreen.kt
+++ b/presentation/planner/src/main/java/com/together/study/planner/share/PlannerShareScreen.kt
@@ -41,6 +41,7 @@ import com.together.study.designsystem.component.topbar.TogedyTopBar
 import com.together.study.designsystem.theme.TogedyTheme
 import com.together.study.planner.model.PlannerSubject
 import com.together.study.planner.model.ShareInfo
+import com.together.study.planner.main.ShareTimeTableContent
 import com.together.study.planner.share.component.PlannerContent
 import com.together.study.planner.share.component.ShareOptionBottomSheet
 import com.together.study.planner.share.component.ShareTimerSection
@@ -203,12 +204,9 @@ fun PlannerShareScreen(
 
                         Spacer(Modifier.width(10.dp))
 
-                        // TODO : TimeTable() 영역으로 변경
-                        Box(
-                            modifier = Modifier
-                                .background(TogedyTheme.colors.gray200)
-                                .height(100.dp)
-                                .weight(1f),
+                        ShareTimeTableContent(
+                            timeTables = plannerShareInfo.timeTables,
+                            modifier = Modifier.weight(1f),
                         )
                     }
                 }


### PR DESCRIPTION
## 📝 Summary
플래너, 플래너 공유 타임테이블 연결 추가

## 🔍 Related Issues
- close #95 

## 📸 Screenshots (선택)
타임테이블 데이터가 없어서 표시가 되지 않네요..ㅎ

## ✅ Checklist (남아있는 사항)
- [ ] 

## 🗒 Additional Notes


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 플래너에 상세 시간표 화면 추가(분 단위 슬롯으로 일정 표시, 자정 넘는 일정 처리 포함)
  * 공유용 시간표 구성 요소 추가하여 플래너 공유 화면에서 실제 시간표 표시

* **UI 개선**
  * 현재 시간을 강조하는 표시기와 우측 화살표 아이콘 추가
  * 일정에 따라 셀 배경 색상으로 시각적 구분 개선
<!-- end of auto-generated comment: release notes by coderabbit.ai -->