### PR TITLE
[Feat/#113] 마이페이지 프로필 수정 사진 업로드 구현

### DIFF
--- a/domain/user/src/main/java/com/together/study/user/usecase/UpdateUserInfoUseCase.kt
+++ b/domain/user/src/main/java/com/together/study/user/usecase/UpdateUserInfoUseCase.kt
@@ -11,12 +11,8 @@ class UpdateUserInfoUseCase @Inject constructor(
         userProfileImage: String?,
         removeUserProfileImage: Boolean,
     ): Result<Unit> {
-        if (userName==null && userProfileImage == null) {
-            return Result.failure(IllegalArgumentException("At least one of userName or userProfileImage must be provided"))
-        }
-
-        if (userProfileImage==null && !removeUserProfileImage) {
-            return Result.failure(IllegalArgumentException("Profile image is empty"))
+        if (userName == null && userProfileImage == null && !removeUserProfileImage) {
+            return Result.failure(IllegalArgumentException("No changes to update"))
         }
 
         return userRepository.updateUserInfo(

--- a/presentation/gallery/src/main/java/com/together/study/gallery/ImageCropScreen.kt
+++ b/presentation/gallery/src/main/java/com/together/study/gallery/ImageCropScreen.kt
@@ -77,6 +77,7 @@ internal fun ImageCropScreen(
     modifier: Modifier = Modifier,
     onBackClick: () -> Unit,
     onUploadSuccess: () -> Unit,
+    onCropSuccess: ((String) -> Unit)? = null,
     viewModel: ImageCropViewModel = hiltViewModel(),
 ) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
@@ -287,7 +288,14 @@ internal fun ImageCropScreen(
 
     LaunchedEffect(uiState) {
         when (val state = uiState) {
-            is ImageCropUiState.Success -> onUploadSuccess()
+            is ImageCropUiState.Success -> {
+                val filePath = state.filePath
+                if (filePath != null && onCropSuccess != null) {
+                    onCropSuccess(filePath)
+                } else {
+                    onUploadSuccess()
+                }
+            }
             is ImageCropUiState.Error -> {
                 TogedyUiEventBus.send(
                     TogedyUiEvent.ShowToast(message = state.message)

--- a/presentation/gallery/src/main/java/com/together/study/gallery/ImageCropUiState.kt
+++ b/presentation/gallery/src/main/java/com/together/study/gallery/ImageCropUiState.kt
@@ -3,6 +3,6 @@ package com.together.study.gallery
 sealed interface ImageCropUiState {
     data object Idle : ImageCropUiState
     data object Loading : ImageCropUiState
-    data object Success : ImageCropUiState
+    data class Success(val filePath: String? = null) : ImageCropUiState
     data class Error(val message: String) : ImageCropUiState
 }

--- a/presentation/gallery/src/main/java/com/together/study/gallery/ImageCropViewModel.kt
+++ b/presentation/gallery/src/main/java/com/together/study/gallery/ImageCropViewModel.kt
@@ -26,18 +26,28 @@ class ImageCropViewModel @Inject constructor(
     private val _uiState = MutableStateFlow<ImageCropUiState>(ImageCropUiState.Idle)
     val uiState: StateFlow<ImageCropUiState> = _uiState.asStateFlow()
 
+    private val isCropOnly = route.date == PROFILE_DATE
+
     fun cropAndUpload(request: CropRequest) {
         viewModelScope.launch {
             _uiState.value = ImageCropUiState.Loading
             cropImageUseCase(request)
                 .onSuccess { filePath ->
-                    uploadImageUseCase(filePath, route.date)
-                        .onSuccess { _uiState.value = ImageCropUiState.Success }
-                        .onFailure { _uiState.value = ImageCropUiState.Error(it.message ?: "업로드 실패") }
+                    if (isCropOnly) {
+                        _uiState.value = ImageCropUiState.Success(filePath = filePath)
+                    } else {
+                        uploadImageUseCase(filePath, route.date)
+                            .onSuccess { _uiState.value = ImageCropUiState.Success() }
+                            .onFailure { _uiState.value = ImageCropUiState.Error(it.message ?: "업로드 실패") }
+                    }
                 }
                 .onFailure {
                     _uiState.value = ImageCropUiState.Error(it.message ?: "크롭 실패")
                 }
         }
+    }
+
+    companion object {
+        const val PROFILE_DATE = "profile"
     }
 }

--- a/presentation/gallery/src/main/java/com/together/study/gallery/navigation/GalleryNavigation.kt
+++ b/presentation/gallery/src/main/java/com/together/study/gallery/navigation/GalleryNavigation.kt
@@ -9,6 +9,7 @@ import androidx.navigation.toRoute
 import com.together.study.common.navigation.Route
 import com.together.study.gallery.GalleryScreen
 import com.together.study.gallery.ImageCropScreen
+import com.together.study.gallery.ImageCropViewModel
 import com.together.study.gallery.type.CropShapeType
 import kotlinx.serialization.Serializable
 
@@ -43,7 +44,7 @@ fun NavGraphBuilder.galleryGraph(
 
     composable<TogedyCropImage> { backStackEntry ->
         val route = backStackEntry.toRoute<TogedyCropImage>()
-        val isProfile = route.date == "profile"
+        val isProfile = route.date == ImageCropViewModel.PROFILE_DATE
         val cropShape = if (isProfile) {
             CropShapeType.Circle
         } else {

--- a/presentation/gallery/src/main/java/com/together/study/gallery/navigation/GalleryNavigation.kt
+++ b/presentation/gallery/src/main/java/com/together/study/gallery/navigation/GalleryNavigation.kt
@@ -27,6 +27,7 @@ fun NavGraphBuilder.galleryGraph(
     modifier: Modifier = Modifier,
     navigateToUp: () -> Unit,
     onUploadSuccess: () -> Unit,
+    onProfileCropSuccess: ((String) -> Unit)? = null,
     navController: NavController,
 ) {
     composable<TogedyGallery> { backStackEntry ->
@@ -42,11 +43,19 @@ fun NavGraphBuilder.galleryGraph(
 
     composable<TogedyCropImage> { backStackEntry ->
         val route = backStackEntry.toRoute<TogedyCropImage>()
+        val isProfile = route.date == "profile"
+        val cropShape = if (isProfile) {
+            CropShapeType.Circle
+        } else {
+            CropShapeType.Rect(aspectRatio = 1f)
+        }
+
         ImageCropScreen(
             imageId = route.imageId,
-            cropShape = CropShapeType.Rect(aspectRatio = 1f),
+            cropShape = cropShape,
             onBackClick = navigateToUp,
             onUploadSuccess = onUploadSuccess,
+            onCropSuccess = if (isProfile) onProfileCropSuccess else null,
             modifier = modifier,
         )
     }

--- a/presentation/main/src/main/java/com/together/study/main/MainScreen.kt
+++ b/presentation/main/src/main/java/com/together/study/main/MainScreen.kt
@@ -37,6 +37,7 @@ import com.together.study.designsystem.component.toast.TogedyToast
 import com.together.study.designsystem.theme.TogedyTheme
 import com.together.study.gallery.navigation.TogedyGallery
 import com.together.study.gallery.navigation.galleryGraph
+import com.together.study.gallery.ImageCropViewModel
 import com.together.study.gallery.navigation.navigateToGallery
 import com.together.study.mypage.navigation.CROPPED_IMAGE_PATH_KEY
 import com.together.study.mypage.navigation.ProfileEdit
@@ -296,7 +297,7 @@ private fun MainNavHost(
             navigateToCreateStudy = navigator.navController::navigateToStudyUpdate,
             navigateToStudyDetail = navigator.navController::navigateToStudyDetail,
             navigateToStudy = navigator.navController::navigateToStudy,
-            navigateToGallery = { navigator.navController.navigateToGallery("profile") },
+            navigateToGallery = { navigator.navController.navigateToGallery(ImageCropViewModel.PROFILE_DATE) },
             navController = navigator.navController,
             modifier = modifier,
         )

--- a/presentation/main/src/main/java/com/together/study/main/MainScreen.kt
+++ b/presentation/main/src/main/java/com/together/study/main/MainScreen.kt
@@ -38,6 +38,8 @@ import com.together.study.designsystem.theme.TogedyTheme
 import com.together.study.gallery.navigation.TogedyGallery
 import com.together.study.gallery.navigation.galleryGraph
 import com.together.study.gallery.navigation.navigateToGallery
+import com.together.study.mypage.navigation.CROPPED_IMAGE_PATH_KEY
+import com.together.study.mypage.navigation.ProfileEdit
 import com.together.study.main.component.MainBottomBar
 import com.together.study.mypage.navigation.myPageGraph
 import com.together.study.planner.navigation.plannerGraph
@@ -294,6 +296,7 @@ private fun MainNavHost(
             navigateToCreateStudy = navigator.navController::navigateToStudyUpdate,
             navigateToStudyDetail = navigator.navController::navigateToStudyDetail,
             navigateToStudy = navigator.navController::navigateToStudy,
+            navigateToGallery = { navigator.navController.navigateToGallery("profile") },
             navController = navigator.navController,
             modifier = modifier,
         )
@@ -308,6 +311,11 @@ private fun MainNavHost(
                     icon = com.together.study.designsystem.R.drawable.ic_check_green,
                     yOffset = togedyToast.toastBasicOffset(),
                 )
+            },
+            onProfileCropSuccess = { filePath ->
+                navigator.navController.getBackStackEntry<ProfileEdit>()
+                    .savedStateHandle[CROPPED_IMAGE_PATH_KEY] = filePath
+                navigator.navController.popBackStack<TogedyGallery>(inclusive = true)
             },
             navController = navigator.navController,
             modifier = modifier,

--- a/presentation/mypage/src/main/java/com/together/study/mypage/component/ImageEditBottomSheet.kt
+++ b/presentation/mypage/src/main/java/com/together/study/mypage/component/ImageEditBottomSheet.kt
@@ -1,0 +1,93 @@
+package com.together.study.mypage.component
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.SheetState
+import androidx.compose.material3.Text
+import androidx.compose.material3.rememberModalBottomSheetState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.together.study.designsystem.component.TogedyBottomSheet
+import com.together.study.designsystem.theme.TogedyTheme
+import com.together.study.util.noRippleClickable
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+internal fun ImageEditBottomSheet(
+    modifier: Modifier = Modifier,
+    sheetState: SheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true),
+    onDismissRequest: () -> Unit,
+    onDeleteClick: () -> Unit,
+    onEditClick: () -> Unit,
+) {
+
+    LaunchedEffect(Unit) { sheetState.expand() }
+
+    TogedyBottomSheet(
+        sheetState = sheetState,
+        onDismissRequest = onDismissRequest,
+        modifier = modifier,
+    ) {
+        Column(
+            modifier = Modifier.padding(horizontal = 20.dp),
+        ) {
+            SelectedItem(
+                itemName = "삭제",
+                textColor = TogedyTheme.colors.red,
+                onClick = onDeleteClick,
+            )
+            SelectedItem(
+                itemName = "이미지 선택",
+                textColor = TogedyTheme.colors.gray800,
+                onClick = onEditClick,
+            )
+            SelectedItem(
+                itemName = "취소",
+                textColor = TogedyTheme.colors.gray500,
+                onClick = onDismissRequest,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SelectedItem(
+    itemName: String,
+    textColor: Color,
+    modifier: Modifier = Modifier,
+    onClick: () -> Unit,
+) {
+    Text(
+        text = itemName,
+        style = TogedyTheme.typography.body14b,
+        color = textColor,
+        textAlign = TextAlign.Center,
+        modifier = modifier
+            .noRippleClickable(onClick)
+            .fillMaxWidth()
+            .padding(vertical = 20.dp),
+    )
+
+    HorizontalDivider(thickness = 1.dp, color = TogedyTheme.colors.gray100)
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Preview
+@Composable
+private fun ImageEditBottomSheetPreview() {
+    TogedyTheme {
+        ImageEditBottomSheet(
+            onDismissRequest = {},
+            onDeleteClick = {},
+            onEditClick = {},
+        )
+    }
+}

--- a/presentation/mypage/src/main/java/com/together/study/mypage/component/ImageEditBottomSheet.kt
+++ b/presentation/mypage/src/main/java/com/together/study/mypage/component/ImageEditBottomSheet.kt
@@ -52,6 +52,7 @@ internal fun ImageEditBottomSheet(
             SelectedItem(
                 itemName = "취소",
                 textColor = TogedyTheme.colors.gray500,
+                showDivider = false,
                 onClick = onDismissRequest,
             )
         }
@@ -63,6 +64,7 @@ private fun SelectedItem(
     itemName: String,
     textColor: Color,
     modifier: Modifier = Modifier,
+    showDivider: Boolean = true,
     onClick: () -> Unit,
 ) {
     Text(
@@ -76,8 +78,9 @@ private fun SelectedItem(
             .padding(vertical = 20.dp),
     )
 
-    HorizontalDivider(thickness = 1.dp, color = TogedyTheme.colors.gray100)
-}
+    if (showDivider) {
+        HorizontalDivider(thickness = 1.dp, color = TogedyTheme.colors.gray100)
+    }}
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Preview

--- a/presentation/mypage/src/main/java/com/together/study/mypage/navigation/MyPageNavigation.kt
+++ b/presentation/mypage/src/main/java/com/together/study/mypage/navigation/MyPageNavigation.kt
@@ -1,6 +1,8 @@
 package com.together.study.mypage.navigation
 
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
@@ -50,6 +52,7 @@ fun NavGraphBuilder.myPageGraph(
     navigateToCreateStudy: () -> Unit,
     navigateToStudyDetail: (Long) -> Unit,
     navigateToStudy: () -> Unit,
+    navigateToGallery: () -> Unit,
     navController: NavController,
     modifier: Modifier = Modifier,
 ) {
@@ -85,10 +88,18 @@ fun NavGraphBuilder.myPageGraph(
         )
     }
 
-    composable<ProfileEdit> {
+    composable<ProfileEdit> { backStackEntry ->
+        val croppedImagePath by backStackEntry.savedStateHandle
+            .getStateFlow<String?>(CROPPED_IMAGE_PATH_KEY, null)
+            .collectAsStateWithLifecycle()
+
         ProfileEditRoute(
             onBackClick = navigateToUp,
-            onGalleryNavigate = {},
+            onGalleryNavigate = navigateToGallery,
+            croppedImagePath = croppedImagePath,
+            onCroppedImageConsumed = {
+                backStackEntry.savedStateHandle.remove<String>(CROPPED_IMAGE_PATH_KEY)
+            },
             modifier = modifier,
         )
     }
@@ -138,3 +149,5 @@ data class NoticeDetail(
 
 @Serializable
 data object Feedback : Route
+
+const val CROPPED_IMAGE_PATH_KEY = "croppedImagePath"

--- a/presentation/mypage/src/main/java/com/together/study/mypage/state/ProfileEditUiState.kt
+++ b/presentation/mypage/src/main/java/com/together/study/mypage/state/ProfileEditUiState.kt
@@ -6,6 +6,7 @@ data class ProfileEditUiState(
     val profileState: UiState<Profile> = UiState.Loading,
     val name: String = "",
     val image: String? = "",
+    val newImagePath: String? = null,
     val isError: Boolean = false,
     val errorMessage: String = "",
     val isDupCheck: Boolean = false,

--- a/presentation/mypage/src/main/java/com/together/study/mypage/ui/account/ProfileEditScreen.kt
+++ b/presentation/mypage/src/main/java/com/together/study/mypage/ui/account/ProfileEditScreen.kt
@@ -99,6 +99,7 @@ internal fun ProfileEditRoute(
     }
 }
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 internal fun ProfileEditScreen(
     userName: String,
@@ -202,6 +203,16 @@ internal fun ProfileEditScreen(
     }
 
     if (isEditBottomSheetVisible) {
-        // TODO: 이미지 바텀시트 연결
+        ImageEditBottomSheet(
+            onDismissRequest = onEditBottomSheetStateChange,
+            onDeleteClick = {
+                onImageDeleteButtonClick(null)
+                onEditBottomSheetStateChange()
+            },
+            onEditClick = {
+                onEditBottomSheetStateChange()
+                onImageEditButtonClick()
+            },
+        )
     }
 }

--- a/presentation/mypage/src/main/java/com/together/study/mypage/ui/account/ProfileEditScreen.kt
+++ b/presentation/mypage/src/main/java/com/together/study/mypage/ui/account/ProfileEditScreen.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -38,6 +39,7 @@ import com.together.study.designsystem.component.toast.LocalTogedyToast
 import com.together.study.designsystem.component.toast.ToastType
 import com.together.study.designsystem.component.topbar.TogedyTopBar
 import com.together.study.designsystem.theme.TogedyTheme
+import com.together.study.mypage.component.ImageEditBottomSheet
 import com.together.study.mypage.component.MyTextField
 import com.together.study.mypage.event.ProfileEditEvent
 import com.together.study.util.noRippleClickable
@@ -46,6 +48,8 @@ import com.together.study.util.noRippleClickable
 internal fun ProfileEditRoute(
     onBackClick: () -> Unit,
     onGalleryNavigate: () -> Unit,
+    croppedImagePath: String? = null,
+    onCroppedImageConsumed: () -> Unit = {},
     modifier: Modifier = Modifier,
     viewModel: ProfileEditViewModel = hiltViewModel(),
 ) {
@@ -53,6 +57,13 @@ internal fun ProfileEditRoute(
 
     val uiState = viewModel.uiState.collectAsStateWithLifecycle()
     val eventFlow = viewModel.eventFlow
+
+    LaunchedEffect(croppedImagePath) {
+        croppedImagePath?.let { path ->
+            viewModel.updateUserProfileImageUrl("file://$path")
+            onCroppedImageConsumed()
+        }
+    }
 
     LaunchedEffect(Unit) {
         eventFlow.collect { event ->

--- a/presentation/mypage/src/main/java/com/together/study/mypage/ui/account/ProfileEditViewModel.kt
+++ b/presentation/mypage/src/main/java/com/together/study/mypage/ui/account/ProfileEditViewModel.kt
@@ -82,11 +82,14 @@ class ProfileEditViewModel @Inject constructor(
     }
 
     fun updateProfile() = viewModelScope.launch {
-        val removeImg = uiState.value.image == null
+        val state = _uiState.value
+        val originImage = (state.profileState as? UiState.Success)?.data?.originImage
+        val isImageChanged = state.image != originImage
+        val removeImg = state.image == null && originImage != null
 
         updateUserInfoUseCase(
-            userName = uiState.value.name,
-            userProfileImage = uiState.value.image,
+            userName = state.name,
+            userProfileImage = if (isImageChanged && !removeImg) state.image else null,
             removeUserProfileImage = removeImg,
         )
             .onSuccess { _eventFlow.emit(ProfileEditEvent.UpdateProfileSuccess) }

--- a/presentation/mypage/src/main/java/com/together/study/mypage/ui/account/ProfileEditViewModel.kt
+++ b/presentation/mypage/src/main/java/com/together/study/mypage/ui/account/ProfileEditViewModel.kt
@@ -84,13 +84,12 @@ class ProfileEditViewModel @Inject constructor(
     fun updateProfile() = viewModelScope.launch {
         val state = _uiState.value
         val originImage = (state.profileState as? UiState.Success)?.data?.originImage
-        val isImageChanged = state.image != originImage
-        val removeImg = state.image == null && originImage != null
+        val isImageRemoved = state.image == null && originImage != null
 
         updateUserInfoUseCase(
             userName = state.name,
-            userProfileImage = if (isImageChanged && !removeImg) state.image else null,
-            removeUserProfileImage = removeImg,
+            userProfileImage = state.newImagePath,
+            removeUserProfileImage = isImageRemoved,
         )
             .onSuccess { _eventFlow.emit(ProfileEditEvent.UpdateProfileSuccess) }
             .onFailure {
@@ -106,7 +105,11 @@ class ProfileEditViewModel @Inject constructor(
     }
 
     fun updateUserProfileImageUrl(url: String?) {
-        _uiState.update { it.copy(image = url) }
+        if (url != null) {
+            _uiState.update { it.copy(image = url, newImagePath = url) }
+        } else {
+            _uiState.update { it.copy(image = null, newImagePath = null) }
+        }
         updateDoneEnabled()
     }
 
@@ -133,7 +136,7 @@ class ProfileEditViewModel @Inject constructor(
                     state.isDupCheck &&
                     state.name != originName
 
-        val isImageChanged = state.image != originImage
+        val isImageChanged = state.newImagePath != null || (state.image == null && originImage != null)
         val doneEnabled = isNameValid || isImageChanged
 
         _uiState.update { it.copy(isDoneEnabled = doneEnabled) }


### PR DESCRIPTION
## 📝 Summary
마이페이지 프로필 수정 사진 업로드 구현

## 🔍 Related Issues
- close #113 

## 📸 Screenshots (선택)

https://github.com/user-attachments/assets/ff884b04-3984-47d5-b426-5c476c5158df



## ✅ Checklist (남아있는 사항)
- [ ] 이미지를 한번 올리고, 닉네임만 수정하는 경우 서버 오류

## 🗒 Additional Notes

[리뷰어가 알아야 할 추가 정보]


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 프로필 이미지 편집 하단 시트 추가(삭제·이미지 선택·취소).
  * 프로필용 원형 크롭 지원 및 크롭 전용 모드(업로드 없이 크롭 결과 반환).
  * 크롭 결과를 프로필 편집 화면으로 전달해 즉시 미리보기/적용 가능.

* **버그 수정**
  * 사용자 정보 업데이트 검증 로직 개선 — 이름만 변경할 때도 정상 처리되도록 수정.
  * 프로필 이미지 변경 감지 로직 보완.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->